### PR TITLE
Add HStack for two 1D Arrays which append to a new 3rd one

### DIFF
--- a/src/NumSharp/Extensions/NdArray.HStack.cs
+++ b/src/NumSharp/Extensions/NdArray.HStack.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NumSharp.Extensions
+{
+    public static partial class NDArrayExtensions
+    {
+        public static NDArray<double> HStack(this NDArray<double> np, NDArray<double> np2 )
+        {
+            var puffer = np.Data.ToList();
+
+            puffer.AddRange(np2.Data);
+
+            var returnValue = new NDArray<double>().Zeros(np.Length + np2.Length);
+            returnValue.Data = puffer;
+
+            return returnValue;
+        }
+    }
+}

--- a/test/NumSharp.UnitTest/Extensions/NdArray.HStack.Test.cs
+++ b/test/NumSharp.UnitTest/Extensions/NdArray.HStack.Test.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using NumSharp.Extensions;
+using System.Linq;
+
+namespace NumSharp.UnitTest.Extensions
+{
+    /// <summary>
+    /// Tests following https://docs.scipy.org/doc/numpy-1.15.0/reference/generated/numpy.hstack.html
+    /// </summary>
+    [TestClass]
+    public class NdArrayHStackTest
+    {
+        [TestMethod]
+        public void HStackTwo1DArrays()
+        {
+            var series1 = new NDArray<double>();
+            series1.Data = new double[]{1, 2, 3};
+            
+            var series2 = new NDArray<double>();
+            series2.Data = new double[]{2,3,4};
+
+            var series3 = series1.HStack(series2);
+
+            var expectedValue = new double[]{1,2,3,2,3,4};
+
+            Assert.IsTrue(Enumerable.SequenceEqual(series3.Data,expectedValue));
+        }
+    }
+}


### PR DESCRIPTION
- implemented very basis of #10 
- it merges 2 arrays to a 3rd one
- slightly different from numpy since hstack on numpy is not an method but global function 
- keep issue open until rest is implemented according to https://docs.scipy.org/doc/numpy-1.15.0/reference/generated/numpy.hstack.html
