### PR TITLE
Back to Extension methods 

### DIFF
--- a/src/NumSharp/Extensions/NdArray.ARange.cs
+++ b/src/NumSharp/Extensions/NdArray.ARange.cs
@@ -4,41 +4,27 @@ using System.ComponentModel;
 using System.Linq;
 using System.Text;
 
-namespace NumSharp
+namespace NumSharp.Extensions
 {
-    public partial class NDArray<TData>
+    public static partial class NDArrayExtensions
     {
-        public NDArray<TData> ARange(int stop, int start = 0, int step = 1)
+        public static NDArray<int> ARange(this NDArray<int> np,int stop, int start = 0, int step = 1)
         {
-            var np = this;
-
             int index = 0;
 
-            var npElementType = typeof(TData);
+            np.Data = Enumerable.Range(start,stop - start)
+                                .Where(x => index++ % step == 0)
+                                .ToArray();
+            return np;
+        }
+        public static NDArray<double> ARange(this NDArray<double> np,int stop, int start = 0, int step = 1)
+        {
+            int index = 0;
 
-            if (!npElementType.IsEnum)
-            {
-                var array = Enumerable.Range(start, stop - start)
-                                          .Where(x => index++ % step == 0)
-                                          .ToArray();
-                dynamic puffer = null;     
-                
-                if (npElementType == typeof(int))
-                {
-                    puffer = array;
-                }
-                else if (npElementType == typeof(double)) 
-                {
-                    puffer = array.Select(x => (double)x )
-                                          .ToArray();
-                }
-                else 
-                {
-
-                }
-                np.Data = (TData[]) puffer;
-            }
-
+            np.Data = Enumerable.Range(start,stop - start)
+                                .Where(x => index++ % step == 0)
+                                .Select(x => (double)x)
+                                .ToArray();
             return np;
         }
     }

--- a/src/NumSharp/Extensions/NdArray.ArgMax.cs
+++ b/src/NumSharp/Extensions/NdArray.ArgMax.cs
@@ -3,14 +3,18 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace NumSharp
+namespace NumSharp.Extensions
 {
-    public partial class NDArray<TData>
+    public static partial class NDArrayExtensions
     {
-        public int ArgMax()
+        public static int ArgMax(this NDArray<double> np )
         {
-            var np = this;
+            var max = np.Data.Max();
 
+            return np.Data.IndexOf(max);
+        }
+        public static int ArgMax(this NDArray<int> np )
+        {
             var max = np.Data.Max();
 
             return np.Data.IndexOf(max);

--- a/src/NumSharp/Extensions/NdArray.Convolve.cs
+++ b/src/NumSharp/Extensions/NdArray.Convolve.cs
@@ -5,9 +5,9 @@ using System.Linq;
 using System.Text;
 using NumSharp;
 
-namespace NumSharp
+namespace NumSharp.Extensions
 {
-    public partial class NDArray<TData>
+    public static partial class NDArrayExtensions
     {
         /// <summary>
         /// Convolution of 2 series  
@@ -16,85 +16,92 @@ namespace NumSharp
         /// <param name="numSharpArray2"></param>
         /// <param name="mode"></param>
         /// <returns></returns>
-        public NDArray<double> Convolve(NDArray<double> numSharpArray2, string mode  = "full")
+        public static NDArray<double> Convolve(this NDArray<double> numSharpArray1, NDArray<double> numSharpArray2, string mode = "full" )
         {
-            dynamic numSharpArray1 = this;
-
             int nf = numSharpArray1.Length;
             int ng = numSharpArray2.Length;
 
             var numSharpReturn = new NDArray<double>();
 
-            if (mode.Equals("full"))
+            switch (mode)
             {
-                int n  = nf + ng - 1;
-
-                var out_ = new double[n];
-
-                for (int idx = 0; idx < n; ++idx)
+                case "full":
                 {
-                    int jmn = (idx >= ng - 1) ? (idx - (ng - 1)) : 0;
-                    int jmx = (idx < nf - 1) ? idx : nf - 1;
+                    int n  = nf + ng - 1;
 
-                    for (int jdx = jmn; jdx <= jmx; ++jdx )
+                    var outArray = new double[n];
+
+                    for (int idx = 0; idx < n; ++idx)
                     {
-                        out_[idx] += ( numSharpArray1[jdx] * numSharpArray2[idx - jdx] );
+                        int jmn = (idx >= ng - 1) ? (idx - (ng - 1)) : 0;
+                        int jmx = (idx < nf - 1) ? idx : nf - 1;
+
+                        for (int jdx = jmn; jdx <= jmx; ++jdx )
+                        {
+                            outArray[idx] += ( numSharpArray1[jdx] * numSharpArray2[idx - jdx] );
+                        }
                     }
-                }
                 
-                numSharpReturn.Data = out_;
-            }
-            else if (mode.Equals("valid"))
-            {
-                var min_v = (nf < ng) ? numSharpArray1 : numSharpArray2;
-                var max_v = (nf < ng) ? numSharpArray2 : numSharpArray1;
+                    numSharpReturn.Data = outArray;
+
+                    break;
+                }
+                case "valid":
+                {
+                    var min_v = (nf < ng) ? numSharpArray1 : numSharpArray2;
+                    var max_v = (nf < ng) ? numSharpArray2 : numSharpArray1;
             
-                int n  = Math.Max(nf, ng) - Math.Min(nf, ng) + 1;
+                    int n  = Math.Max(nf, ng) - Math.Min(nf, ng) + 1;
                 
-                double[] out_ = new double[n];
+                    double[] outArray = new double[n];
   
-                for(int idx = 0; idx < n; ++idx) 
-                {
-                    int kdx = idx; 
-                    
-                    for(int jdx = (min_v.Length - 1); jdx >= 0; --jdx) 
+                    for(int idx = 0; idx < n; ++idx) 
                     {
-                        out_[idx] += min_v[jdx] * max_v[kdx];
-                        ++kdx;
+                        int kdx = idx; 
+                    
+                        for(int jdx = (min_v.Length - 1); jdx >= 0; --jdx) 
+                        {
+                            outArray[idx] += min_v[jdx] * max_v[kdx];
+                            ++kdx;
+                        }
                     }
-                }
-                numSharpReturn.Data = out_;
-            }
-            else if (mode.Equals("same"))
-            {
-                // followed the discussion on 
-                // https://stackoverflow.com/questions/38194270/matlab-convolution-same-to-numpy-convolve
-                // implemented numpy convolve because we follow numpy
-                var npad = numSharpArray2.Length - 1;
 
-                if (npad % 2 == 1)
-                {
-                    npad = (int) Math.Floor(((double)npad) / 2.0);
+                    numSharpReturn.Data = outArray;
                     
-                    numSharpArray1.Data.ToList().AddRange(new double[npad+1]);
-                    var puffer = (new double[npad]).ToList();
-                    puffer.AddRange(numSharpArray1.Data);
-                    numSharpArray1.Data = puffer; 
+                    break;
                 }
-                else 
+                case "same":
                 {
-                    npad = npad / 2;
-                    
-                    var puffer = ((double[]) numSharpArray1.Data).ToList(); 
-                    puffer.AddRange(new double[npad]);
-                    numSharpArray1.Data = puffer;
-                    
-                    puffer = (new double[npad]).ToList();
-                    puffer.AddRange(numSharpArray1.Data);
-                    numSharpArray1.Data = puffer; 
-                }
+                    // followed the discussion on 
+                    // https://stackoverflow.com/questions/38194270/matlab-convolution-same-to-numpy-convolve
+                    // implemented numpy convolve because we follow numpy
+                    var npad = numSharpArray2.Length - 1;
 
-                numSharpReturn = numSharpArray1.Convolve(numSharpArray2,"valid");
+                    if (npad % 2 == 1)
+                    {
+                        npad = (int) Math.Floor(((double)npad) / 2.0);
+                    
+                        numSharpArray1.Data.ToList().AddRange(new double[npad+1]);
+                        var puffer = (new double[npad]).ToList();
+                        puffer.AddRange(numSharpArray1.Data);
+                        numSharpArray1.Data = puffer; 
+                    }
+                    else 
+                    {
+                        npad = npad / 2;
+                    
+                        var puffer = ((double[]) numSharpArray1.Data).ToList(); 
+                        puffer.AddRange(new double[npad]);
+                        numSharpArray1.Data = puffer;
+                    
+                        puffer = (new double[npad]).ToList();
+                        puffer.AddRange(numSharpArray1.Data);
+                        numSharpArray1.Data = puffer; 
+                    }
+
+                    numSharpReturn = numSharpArray1.Convolve(numSharpArray2,"valid");
+                    break;
+                }
             }
             return numSharpReturn;
         }

--- a/src/NumSharp/Extensions/NdArray.Delete.cs
+++ b/src/NumSharp/Extensions/NdArray.Delete.cs
@@ -3,14 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace NumSharp
+namespace NumSharp.Extensions
 {
-    public partial class NDArray<TData>
+    public static partial class NDArrayExtensions
     {
-        public NDArray<TData> Delete(IEnumerable<TData> delete)
-        {
-            var np = this;
-            
+        public static NDArray<TData> Delete<TData>(this NDArray<TData> np,  IEnumerable<TData> delete)
+        {            
             return np.Array(np.Data.Where(x => !delete.Contains(x)));
         }
     }

--- a/src/NumSharp/Extensions/NdArray.Dot.cs
+++ b/src/NumSharp/Extensions/NdArray.Dot.cs
@@ -3,49 +3,37 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace NumSharp
+namespace NumSharp.Extensions
 {
-    public partial class NDArray<TData>
+    public static partial class NDArrayExtensions
     {
-        public TData Dot(NDArray<TData> np)
+        public static double Dot(this NDArray<double> np, NDArray<double> np2)
         {
-            dynamic array1 = this.Data;
-            dynamic array2 = np.Data;
-
-            Type elementType = typeof(TData);
-
-            dynamic sumDyn = null;
-
-            if (elementType == typeof(double))
-            {
-                double[] array1Double = (double[]) array1;
-                double[] array2Double = (double[]) array2;
-
-                double sum = 0;
-
-                for (int idx = 0; idx < array1Double.Length; idx++)
-                {
-                    sum += array1Double[idx] * array2Double[idx];
-                }
-
-                sumDyn = sum;
-            }
-            else if( elementType == typeof(int))
-            {
-                int[] array1Double = (int[]) array1;
-                int[] array2Double = (int[]) array2;
-
-                int sum = 0;
-
-                for (int idx = 0; idx < array1Double.Length; idx++)
-                {
-                    sum += array1Double[idx] * array2Double[idx];
-                }
-
-                sumDyn = sum;
-            }
+            double[] array1Double = np.Data.ToArray();
+            double[] array2Double = np2.Data.ToArray();
             
-            return (TData) sumDyn;
+            double sum = 0;
+
+            for (int idx = 0; idx < array1Double.Length; idx++)
+            {
+                sum += array1Double[idx] * array2Double[idx];
+            }
+
+            return sum;
+        }
+        public static int Dot(this NDArray<int> np, NDArray<int> np2)
+        {
+            int[] array1Double = np.Data.ToArray();
+            int[] array2Double = np2.Data.ToArray();
+            
+            int sum = 0;
+
+            for (int idx = 0; idx < array1Double.Length; idx++)
+            {
+                sum += array1Double[idx] * array2Double[idx];
+            }
+
+            return sum;
         }
     }
 }

--- a/src/NumSharp/NdArray.ExtensionLinking.cs
+++ b/src/NumSharp/NdArray.ExtensionLinking.cs
@@ -1,0 +1,76 @@
+﻿/*
+ * NumSharp
+ * Copyright (C) 2018 Haiping Chen
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License 2.0 as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the Apache License 2.0
+ * along with this program.  If not, see <http://www.apache.org/licenses/LICENSE-2.0/>.
+ */
+
+using NumSharp.Extensions;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Dynamic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace NumSharp
+{
+    /// <summary>
+    /// A powerful N-dimensional array object
+    /// Inspired from https://www.numpy.org/devdocs/user/quickstart.html
+    /// </summary>
+    public partial class NDArray<TData>
+    {
+        public NDArray<TData> HStack(NDArray<TData> np2 )
+        {
+            dynamic npDyn = this;
+            dynamic np2Dyn = np2;
+
+            return NumSharp.Extensions.NDArrayExtensions.HStack(npDyn,np2Dyn);
+        }
+        public NDArray<TData> ARange(int stop, int start = 0, int step = 1)
+        {
+            dynamic npDyn = this;
+
+            dynamic npResult = NumSharp.Extensions.NDArrayExtensions.ARange(npDyn, stop,start,step);
+
+            return npResult;
+        }
+        public int ArgMax()
+        {
+            dynamic npDyn = this;
+
+            return NumSharp.Extensions.NDArrayExtensions.ArgMax(npDyn);
+        }
+        public NDArray<TData> Convolve(NDArray<TData> np2, string mode = "full")
+        {
+            dynamic npDyn = this;
+            dynamic np2Dyn = np2;
+
+            return NumSharp.Extensions.NDArrayExtensions.Convolve(npDyn, np2Dyn,mode);
+        }
+        public TData Dot(NDArray<TData> np2)
+        {
+            dynamic np1Dyn = this;
+            dynamic np2Dyn = np2;
+
+            return NumSharp.Extensions.NDArrayExtensions.Dot(np1Dyn,np2Dyn);
+        }
+        public NDArray<TData> Delete(IEnumerable<TData> delete)
+        {
+            return NumSharp.Extensions.NDArrayExtensions.Delete(this, delete);
+        }
+    }
+}


### PR DESCRIPTION
After some experiments and playing around find that extension methods are better for beginning. 

So we can implement all APIs for double first and later come with int, float, complex, quaternion, etc. 
Since we can decide which generic Type we want to implement --> easy to use. 

In order to use them in Powershell (I will add maybe script in UnitTest project simple to show) added a file called "NdArray.ExtensionLinking.cs" which honestly just "shows" all extension methods as true methods.  