### PR TITLE
Extended Dot method by scalar multiplication

### DIFF
--- a/src/NumSharp/Extensions/NdArray.Array.cs
+++ b/src/NumSharp/Extensions/NdArray.Array.cs
@@ -34,5 +34,21 @@ namespace NumSharp
 
             return puffer.ReShape(array.Count, np.NDim);
         }
+        public NDArray<NDArray<double>> Array(double[,] array)
+        {
+            NDArray<NDArray<double>> returnArray = new NDArray<NDArray<double>>();
+
+            returnArray.Data = new NDArray<double>[array.GetLength(0)];
+            for (int idx = 0;idx < array.GetLength(0); idx++)
+            {
+                returnArray.Data[idx] = new NDArray<double>();
+                returnArray.Data[idx].Data = new double[array.GetLength(1)];
+                for (int jdx =0; jdx < array.GetLength(1); jdx++)
+                {
+                    returnArray.Data[idx].Data[jdx] = array[idx,jdx];
+                }
+            }
+            return returnArray;
+        }
     }
 }

--- a/src/NumSharp/Extensions/NdArray.Dot.cs
+++ b/src/NumSharp/Extensions/NdArray.Dot.cs
@@ -2,12 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Numerics;
 
 namespace NumSharp.Extensions
 {
     public static partial class NDArrayExtensions
     {
-        public static double Dot(this NDArray<double> np, NDArray<double> np2)
+        public static NDArray<double> Dot(this NDArray<double> np, NDArray<double> np2)
         {
             double[] array1Double = np.Data.ToArray();
             double[] array2Double = np2.Data.ToArray();
@@ -19,7 +20,7 @@ namespace NumSharp.Extensions
                 sum += array1Double[idx] * array2Double[idx];
             }
 
-            return sum;
+            return new NDArray<double>().Array(new double[]{sum});
         }
         public static int Dot(this NDArray<int> np, NDArray<int> np2)
         {
@@ -34,6 +35,49 @@ namespace NumSharp.Extensions
             }
 
             return sum;
+        }
+        public static NDArray<NDArray<double>> Dot(this NDArray<NDArray<double>> np,NDArray<NDArray<double>> np2)
+        {
+            // the following lines are slow performance I guess
+            int numOfLines = np.Length;
+            int numOfColumns = np2[0].Length;
+
+            NDArray<NDArray<double>> result = new NDArray<NDArray<double>>();
+            result.Data = new NDArray<double>[numOfLines];
+            
+            for (int idx =0; idx < numOfLines;idx++)
+            {
+                result.Data[idx] = new NDArray<double>();
+                result.Data[idx].Data = new double[numOfColumns];    
+            }
+
+            for (int idx = 0; idx < numOfLines;idx++)
+            {
+                for( int jdx = 0; jdx < numOfColumns; jdx++)
+                {
+                    result[idx][jdx] = 0;
+                    for (int kdx = 0; kdx < np2.Length; kdx++)
+                    {
+                        result[idx][jdx] += np[idx][kdx] * np2[kdx][jdx];
+                    }
+                }
+            }
+
+            return result;
+        }
+        public static NDArray<Complex> Dot(this NDArray<Complex> np, NDArray<Complex> np2)
+        {
+            var array1Complex = np.Data.ToArray();
+            var array2Complex = np2.Data.ToArray();
+
+            Complex sum = 0;
+
+            for (int idx = 0; idx < array1Complex.Length; idx++)
+            {
+                sum += array1Complex[idx] * array2Complex[idx];
+            }
+
+            return new NDArray<Complex>().Array(new Complex[]{new Complex(sum.Real,sum.Imaginary)} );
         }
         public static NDArray<double> Dot(this NDArray<double> np, double scalar)
         {

--- a/src/NumSharp/Extensions/NdArray.Dot.cs
+++ b/src/NumSharp/Extensions/NdArray.Dot.cs
@@ -35,5 +35,25 @@ namespace NumSharp.Extensions
 
             return sum;
         }
+        public static NDArray<double> Dot(this NDArray<double> np, double scalar)
+        {
+            double[] array1Double = np.Data.ToArray();
+
+            array1Double = array1Double.Select(x => scalar * x).ToArray();
+            
+            np.Data = array1Double;
+
+            return np;
+        }
+        public static NDArray<float> Dot(this NDArray<float> np, float scalar)
+        {
+            np.Data = np.Data.Select(x => x * scalar).ToArray();
+            return np;
+        }
+        public static NDArray<int> Dot(this NDArray<int> np, int scalar)
+        {
+            np.Data = np.Data.Select(x => x * scalar).ToArray();
+            return np;
+        }
     }
 }

--- a/src/NumSharp/NdArray.ExtensionLinking.cs
+++ b/src/NumSharp/NdArray.ExtensionLinking.cs
@@ -68,6 +68,13 @@ namespace NumSharp
 
             return NumSharp.Extensions.NDArrayExtensions.Dot(np1Dyn,np2Dyn);
         }
+        public NDArray<TData> Dot(TData scalar)
+        {
+            dynamic np1Dyn = this;
+            dynamic scalarDyn = scalar;
+            
+            return NumSharp.Extensions.NDArrayExtensions.Dot(np1Dyn,scalarDyn);
+        }
         public NDArray<TData> Delete(IEnumerable<TData> delete)
         {
             return NumSharp.Extensions.NDArrayExtensions.Delete(this, delete);

--- a/src/NumSharp/NdArray.ExtensionLinking.cs
+++ b/src/NumSharp/NdArray.ExtensionLinking.cs
@@ -61,7 +61,7 @@ namespace NumSharp
 
             return NumSharp.Extensions.NDArrayExtensions.Convolve(npDyn, np2Dyn,mode);
         }
-        public TData Dot(NDArray<TData> np2)
+        public NDArray<TData> Dot(NDArray<TData> np2)
         {
             dynamic np1Dyn = this;
             dynamic np2Dyn = np2;

--- a/test/NumSharp.UnitTest/Extensions/NdArray.Dot.Test.cs
+++ b/test/NumSharp.UnitTest/Extensions/NdArray.Dot.Test.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using NumSharp.Extensions;
 using System.Linq;
+using System.Numerics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace NumSharp.UnitTest.Extensions
@@ -24,33 +25,28 @@ namespace NumSharp.UnitTest.Extensions
             series2.Data = new double[]{0, 1, 0.5};
 
             var innerProduct = series1.Dot(series2);
-            Assert.IsTrue(innerProduct == 3.5);
+            Assert.IsTrue(innerProduct[0] == 3.5);
         }
         [TestMethod]
-        public void ConvoleValid()
+        public void MatrixMultiply()
         {
-            var series1 = new NDArray<int>();
-            series1.Data = new int[]{1, 2, 3};
-            
-            var series2 = new NDArray<int>();
-            series2.Data = new int[]{2, 3, 4};
+            var matrix1 = new NDArray<NDArray<double>>().Array(new double[,] {{1,2},{3,4},{5,6} });
+            var matrix2 = new NDArray<NDArray<double>>().Array(new double[,] {{7,8,9},{10,11,12}});
 
-            var innerProduct = series1.Dot(series2);
+            var matrix3 = matrix1.Dot(matrix2);
             
-            Assert.IsTrue(innerProduct == 20);
+            var expectedResult = new NDArray<NDArray<double>>().Array(new double[,]{{27,30,33}, {61,68,75},{95,106,117}});
         }
         [TestMethod]
-        public void ConvoleSame()
+        public void DotTwo1DComplex()
         {
-            var series1 = new NDArray<double>();
-            series1.Data = new double[]{1, 2, 3};
+            var series1 = new NDArray<Complex>().Array(new Complex[]{new Complex(0,2),new Complex(0,3)});
             
-            var series2 = new NDArray<double>();
-            series2.Data = new double[]{0, 1, 0.5};
+            var series2 = new NDArray<Complex>().Array(new Complex[]{new Complex(0,2),new Complex(0,3)});
+        
+            var series3 = series1.Dot(series2);
 
-            var series3 = series1.Convolve(series2, "same");
-
-            double[] expectedResult = new double[]{1, 2.5, 4};
+            Complex[] expectedResult = new Complex[]{new Complex(-13,0)};
 
             Assert.IsTrue(Enumerable.SequenceEqual(series3.Data.ToArray(),expectedResult));
             


### PR DESCRIPTION
- noticed that numpy.dot allows scalar as input 
- scalar is simple multiply all values in array
- added extension linking for use in Powershell and F#