### PR TITLE
Add eye method for 2D arrays (not higher dimension)

### DIFF
--- a/src/NumSharp/Extensions/NdArray.Eye.cs
+++ b/src/NumSharp/Extensions/NdArray.Eye.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace NumSharp.Extensions
+{
+    public static partial class NDArrayExtensions
+    {
+        public static NDArray<int> Eye(this NDArray<int> np,int dim, int diagonalIndex = 0)
+        {
+            int noOfDiagElement = dim - Math.Abs(diagonalIndex);
+
+            if((np.NDim == 1) && (dim != 1))
+            {
+                np.Zeros(dim,dim);
+            }
+            else 
+            {
+                np.Zeros(np.Shape.ToArray());
+            }
+            
+            np.Data = new int[np.Size];
+
+            for(int idx = 0; idx < noOfDiagElement;idx++ )
+             {
+                 np.Data[diagonalIndex + idx + idx * np.Shape[1]] = 1;
+             }
+            
+            return np;
+        }
+        public static NDArray<double> Eye(this NDArray<double> np,int dim, int diagonalIndex = 0)
+        {
+            int noOfDiagElement = dim - Math.Abs(diagonalIndex);
+
+            if((np.NDim == 1) && (dim != 1))
+            {
+                np.Zeros(dim,dim);
+            }
+            else 
+            {
+                np.Zeros(np.Shape.ToArray());
+            }
+            
+            np.Data = new double[np.Size];
+
+            if (diagonalIndex >= 0)
+            {
+                for(int idx = 0; idx < noOfDiagElement;idx++ )
+                {
+                     np.Data[diagonalIndex + idx + idx * np.Shape[1]] = 1;
+                }
+            }
+            else
+            {
+                for(int idx = 0; idx < noOfDiagElement;idx++ )
+                {
+                     np.Data[(-1)*diagonalIndex * dim + idx + idx * np.Shape[1]] = 1;
+                }
+            }
+
+            return np;
+        }
+    }
+}

--- a/test/NumSharp.UnitTest/Extensions/NdArray.Eye.Test.cs
+++ b/test/NumSharp.UnitTest/Extensions/NdArray.Eye.Test.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using NumSharp.Extensions;
+using System.Linq;
+
+namespace NumSharp.UnitTest.Extensions
+{
+    [TestClass]
+    public class NdArrayEyeTest
+    {
+        [TestMethod]
+        public void SimpleIntMatrix()
+        {
+            var np = new NDArray<int>().Eye(5);
+
+            Assert.IsTrue(np[0,0] == 1);
+            Assert.IsTrue(np[1,1] == 1);
+            Assert.IsTrue(np[2,2] == 1);
+            Assert.IsTrue(np[3,3] == 1);
+            Assert.IsTrue(np[4,4] == 1);
+
+            int[] elementsZero = np.Data.Where((x) => x == 0 ).ToArray();
+
+            Assert.IsTrue(elementsZero.Length == 20);
+        }
+        [TestMethod]
+        public void SimpleDoubleMatrix()
+        {
+            var np = new NDArray<double>().Eye(5);
+
+            Assert.IsTrue(np[0,0] == 1);
+            Assert.IsTrue(np[1,1] == 1);
+            Assert.IsTrue(np[2,2] == 1);
+            Assert.IsTrue(np[3,3] == 1);
+            Assert.IsTrue(np[4,4] == 1);
+
+            double[] elementsZero = np.Data.Where((x) => x == 0.0 ).ToArray();
+
+            Assert.IsTrue(elementsZero.Length == 20);
+        }
+        [TestMethod]
+        public void DoubleMatrix2DiagonalLeft()
+        {
+            var np = new NDArray<double>().Eye(5,-2);
+
+            Assert.IsTrue(np[2,0] == 1);
+            Assert.IsTrue(np[3,1] == 1);
+            Assert.IsTrue(np[4,2] == 1);
+
+            Assert.IsTrue(np.Data.Where(x => x ==0).ToArray().Length ==22);        
+        }
+        [TestMethod]
+        public void DoubleMatrix2DiagonalRight()
+        {
+            var np = new NDArray<double>().Eye(5,2);
+
+            Assert.IsTrue(np[0,2] == 1);
+            Assert.IsTrue(np[1,3] == 1);
+            Assert.IsTrue(np[2,4] == 1);
+
+            Assert.IsTrue(np.Data.Where(x => x ==0).ToArray().Length ==22);        
+        }
+
+    }
+}


### PR DESCRIPTION
- the eye method is until now just constructed for 2D arrays so matrix
- need to generalize it to ND
- test for normal diagonal, -2 and +2 shifted diagonal