### PR TITLE
Add once method for NDArrays

### DIFF
--- a/src/NumSharp/Extensions/NdArray.Onces.cs
+++ b/src/NumSharp/Extensions/NdArray.Onces.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Numerics;
+
+namespace NumSharp.Extensions
+{
+    public static partial class NDArrayExtensions
+    {
+        public static NDArray<T> Onces<T>(this NDArray<T> np, params int[] shape)
+        {
+            int numOFElements = 1;
+            for(int idx = 0;idx < shape.Length;idx++)
+            {
+                numOFElements *= shape[idx];
+            }
+
+            np.Data= new T[numOFElements];
+            np.Shape = shape.ToList();
+
+            dynamic onceArray = np.Data;
+
+            var elementType = typeof(T);
+
+            switch (elementType.Name)
+            {
+                case ("Int32"): onceArray = ((int[])onceArray).Select(x => 1).ToArray(); break;
+                case ("Double"): onceArray = ((double[])onceArray).Select(x => 1.0).ToArray(); break;
+                case ("Float"): onceArray = ((float[])onceArray).Select(x => 1.0).ToArray(); break;
+                case ("Complex"): onceArray = ((Complex[])onceArray).Select(x => new Complex(1,0)).ToArray(); break;
+                case ("Quaternion"): onceArray = ((Quaternion[])onceArray).Select(x => new Quaternion(new Vector3(0,0,0),1)).ToArray(); break;
+            } 
+
+            np.Data = (T[])onceArray;
+
+            return np;
+        }
+    }
+}

--- a/src/NumSharp/NdArray.ExtensionLinking.cs
+++ b/src/NumSharp/NdArray.ExtensionLinking.cs
@@ -91,5 +91,9 @@ namespace NumSharp
             dynamic np = this;
             return NumSharp.Extensions.NDArrayExtensions.AsMatrix(np);
         }
+        public NDArray<T> Onces(params int[] shape)
+        {
+            return NumSharp.Extensions.NDArrayExtensions.Onces(this,shape);
+        }
     }
 }

--- a/test/NumSharp.UnitTest/Extensions/NdArray.Onces.Test.cs
+++ b/test/NumSharp.UnitTest/Extensions/NdArray.Onces.Test.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using NumSharp.Extensions;
+using System.Linq;
+
+namespace NumSharp.UnitTest.Extensions
+{
+    [TestClass]
+    public class NdArrayOncesTest
+    {
+        [TestMethod]
+        public void SimpleInt1D()
+        {
+            var np = new NDArray<int>().Onces(5);
+
+            Assert.IsTrue(np.Data.Where(x => x==1).ToArray().Length == 5);
+        }
+        [TestMethod]
+        public void SimpleInt2D()
+        {
+            var np = new NDArray<int>().Onces(5,5);
+
+            Assert.IsTrue(np.Data.Where(x => x==1).ToArray().Length == 25);
+        }
+        [TestMethod]
+        public void SimpleDouble3D()
+        {
+            var np = new NDArray<double>().Onces(5,5,5);
+
+            Assert.IsTrue(np.Data.Where(x => x==1).ToArray().Length == 125);
+        }
+    }
+}


### PR DESCRIPTION
- independent of NDim (matrix, vector, tensor, ....  all shall be fine)
- one method for all data types (including switch data type)
