### PR TITLE
Changed dynamic output of ToDotNetArray method to generic interface 

### DIFF
--- a/src/NumSharp/NdArray.cs
+++ b/src/NumSharp/NdArray.cs
@@ -213,7 +213,7 @@ namespace NumSharp
         {
             return np.Data[0].Equals(obj);
         }
-        public dynamic ToDotNetArray()
+        public TCast ToDotNetArray<TCast>()
         {
             dynamic dotNetArray = null;
             switch (this.NDim)
@@ -256,7 +256,8 @@ namespace NumSharp
                     break;
                 }
             }
-            return dotNetArray;
+            TCast castedDotNetArray = (TCast)dotNetArray;
+            return castedDotNetArray;
         }
         protected string _ToMatrixString()
         {

--- a/test/NumSharp.UnitTest/NdArray.Test.cs
+++ b/test/NumSharp.UnitTest/NdArray.Test.cs
@@ -48,7 +48,7 @@ namespace NumSharp.UnitTest
         {
             var np1 = new NDArray<double>().ARange(9);
 
-            double[] np1_ = (double[])np1.ToDotNetArray();
+            double[] np1_ = np1.ToDotNetArray<double[]>();
 
             Assert.IsTrue(Enumerable.SequenceEqual(np1_,np1.Data));
         } 
@@ -57,7 +57,7 @@ namespace NumSharp.UnitTest
         {
             var np1 = new NDArray<double>().ARange(9).ReShape(3,3);
 
-            double[][] np1_ = (double[][])np1.ToDotNetArray();
+            double[][] np1_ = np1.ToDotNetArray<double[][]>();
 
             for (int idx = 0; idx < 3; idx ++)
             {
@@ -72,7 +72,7 @@ namespace NumSharp.UnitTest
         {
             var np1 = new NDArray<double>().ARange(27).ReShape(3,3,3);
 
-            double[][][] np1_ = (double[][][])np1.ToDotNetArray();
+            double[][][] np1_ = np1.ToDotNetArray<double[][][]>();
 
             for (int idx = 0; idx < 3; idx ++)
             {


### PR DESCRIPTION
- followed suggest in issue with "ToDotNetArray<double[][]>() strategy 
- could give power to do array and type cast with one method
  e.g. var np = NDArray< double >().ARange(9).Reshape(3,3).ToDotNetArray< int [][] >();
