### PR TITLE
Improved Format of ToString()

### DIFF
--- a/test/NumSharp.UnitTest/NdArray.Test.cs
+++ b/test/NumSharp.UnitTest/NdArray.Test.cs
@@ -31,6 +31,28 @@ namespace NumSharp.UnitTest
             Assert.IsTrue(n2[1] == 11);
         }
         [TestMethod]
+        public void StringCheck()
+        {
+            var np = new NDArray<double>().ARange(9).ReShape(3,3);
+
+            var random = new Random();
+            np.Data = np.Data.Select(x => x + random.NextDouble()).ToArray();
+            np.Data[1] = 1;
+            np.Data[2] -= 4;
+            np.Data[3] -= 20;
+            np.Data[8] += 23;
+
+            var stringOfNp = np.ToString();
+
+            Assert.IsTrue(stringOfNp.Contains("[[  0."));
+
+            np = new NDArray<double>().ARange(9).ReShape(3,3);
+
+            stringOfNp = np.ToString();        
+
+            Assert.IsTrue(stringOfNp.Contains("([[ 0,"));
+        }
+        [TestMethod]
         public void DimOrder()
         {
             NDArray<double> np1 = new NDArray<double>().Zeros(2,2);


### PR DESCRIPTION
- for 2D arrays so matrix 
- until now quite complex since all numbers converted to string, digits before "." and after are counted and dots shall be all at some location in matrix (column like) in this string
- @Oceania2018 you can try it on Visual Studio :D if format still now right let me know 
- just tested it for 2D arrays in Powershell 